### PR TITLE
ci(rubocop): run ci on lib or spec change #11(2)

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,20 @@
+name: RuboCop
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'lib/**'
+      - 'spec/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'lib/**'
+      - 'spec/**'
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: andrewmcodes/rubocop-linter-action@v3.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,3 @@ jobs:
           ruby-version: 2.5
           bundler-cache: true
       - run: bundle exec rspec
-  rubocop:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: RuboCop Linter
-        uses: andrewmcodes/rubocop-linter-action@v3.3.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Only run RuboCop when there are code changes within the `lib` or `spec` directories.